### PR TITLE
Re-sync with internal repository

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,11 @@
 # Contributing to Facebook Open Source Projects
+
 We want to make contributing to Facebook Open Source Projects as easy and
 transparent as possible.
 
-## Pull Requests We actively welcome your pull requests.
+## Pull Requests
+
+We actively welcome your pull requests.
 
 1. Fork the repo and create your branch from `master`.
 2. If you've added code that should be tested, add tests.
@@ -11,20 +14,24 @@ transparent as possible.
 5. Make sure your code lints.
 6. If you haven't already, complete the Contributor License Agreement ("CLA").
 
-## Contributor License Agreement ("CLA") In order to accept your pull request,
-we need you to submit a CLA. You only need to do this once to work on any of
-Facebook's open source projects.
+## Contributor License Agreement ("CLA")
+
+In order to accept your pull request, we need you to submit a CLA. You only
+need to do this once to work on any of Facebook's open source projects.
 
 Complete your CLA here: <https://code.facebook.com/cla>
 
-## Issues We use GitHub issues to track public bugs. Please ensure your
-description is clear and has sufficient instructions to be able to reproduce
-the issue.
+## Issues
+
+We use GitHub issues to track public bugs. Please ensure your description is
+clear and has sufficient instructions to be able to reproduce the issue.
 
 Facebook has a [bounty program](https://www.facebook.com/whitehat/) for the
 safe disclosure of security bugs. In those cases, please go through the process
 outlined on that page and do not file a public issue.
 
-## License By contributing to Facebook Open Source Projects, you agree that
-your contributions will be licensed under the LICENSE file in the root
-directory of each project's source tree.
+## License
+
+By contributing to Facebook Open Source Projects, you agree that your
+contributions will be licensed under the LICENSE file in the root directory of
+each project's source tree.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,7 @@
+# Reporting and Fixing Security Issues
+
+Please do not open GitHub issues or pull requests - this makes the problem immediately visible to everyone, including malicious actors. Security issues in this open source project can be safely reported via Facebook's Whitehat Bug Bounty program:
+
+https://www.facebook.com/whitehat
+
+Facebook's security team will triage your report and determine whether or not is it eligible for a bounty under our program.


### PR DESCRIPTION
The internal and external repositories are out of sync. This attempts to brings them back in sync by patching the GitHub repository. Please carefully review this patch. You must disable ShipIt for your project in order to merge this pull request. DO NOT IMPORT this pull request. Instead, merge it directly on GitHub using the MERGE BUTTON. Re-enable ShipIt after merging.